### PR TITLE
Fix comment spelling

### DIFF
--- a/batch_correct.R
+++ b/batch_correct.R
@@ -20,7 +20,7 @@ colnames(cts_mat) <- gsub("\\.", "-", colnames(cts_mat))
 # Read the sample file
 samples <- read.csv(sample_file, row.names=1, header=TRUE)
 
-## Use the new ComBa-ref to adjust data
+## Use the new ComBat-ref to adjust data
 start_time <- Sys.time()
 new_mat <- ComBat_ref(counts=cts_mat, batch=samples$batch, group=samples$group, genewise.disp=FALSE)
 end_time <- Sys.time()

--- a/real_data_application/gfrn_DE.R
+++ b/real_data_application/gfrn_DE.R
@@ -52,7 +52,7 @@ combatseq_sub <- ComBat_seq(counts=cts_sub, batch=batch_sub, group=group_sub,
 ## Use original ComBat on logCPM
 combat_sub <- ComBat(cpm(cts_sub, log=TRUE), batch=batch_sub, mod=model.matrix(~group_sub))
 
-## Use the new ComBa-ref to adjust data
+## Use the new ComBat-ref to adjust data
 start_time <- Sys.time()
 combat_new <- ComBat_ref(counts=cts_sub, batch=batch_sub, group=group_sub, genewise.disp=FALSE)
 end_time <- Sys.time()

--- a/real_data_application/gfrn_application.R
+++ b/real_data_application/gfrn_application.R
@@ -51,7 +51,7 @@ print(end_time - start_time)
 
 #combat_sub <- sva::ComBat(cpm(cts_sub, log=TRUE), batch=batch_sub, mod=model.matrix(~group_sub))
 
-## Use the new ComBa-ref to adjust data
+## Use the new ComBat-ref to adjust data
 start_time <- Sys.time()
 combat_sub <- ComBat_ref(counts=cts_sub, batch=batch_sub, group=group_sub, genewise.disp=FALSE)
 end_time <- Sys.time()


### PR DESCRIPTION
## Summary
- fix references to `ComBat-ref` in comments

## Testing
- `Rscript -e "cat('test')"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6889181cfea0832ba6a947c540c2095d